### PR TITLE
Algorithm notation

### DIFF
--- a/Labs/AffineTransformations/AffineTransformations.tex
+++ b/Labs/AffineTransformations/AffineTransformations.tex
@@ -145,12 +145,12 @@ This is because reflections, dilations, and shears provide us with all the eleme
 \includegraphics[width=\textwidth]{translate.pdf}
 \caption{
 An example of a translation.
-The top image was translated by the vector $(2, 0)^T$ to produce the bottom image.}
+The top image was translated by the vector $(2, 0)\trp$ to produce the bottom image.}
 \label{fig:translation}
 \end{figure}
 
 A translation is a map $T: \mathbb{R}^2 \rightarrow \mathbb{R}^2$ defined by $T(\mathbf{x}) = \mathbf{x}+\mathbf{b}$ where $\mathbf{b} \in \mathbb{R}^2$. 
-For example, if $\mathbf{b} = (2, 0)^T$, then applying $T$ to an image will shift it left by 2. 
+For example, if $\mathbf{b} = (2, 0)\trp$, then applying $T$ to an image will shift it left by 2. 
 This translation is illustrated in Figure \ref{fig:translation}.
 
 
@@ -429,8 +429,8 @@ Furthermore, it is \emph{numerically stable}, which means that round-off errors 
 Because of its efficiency and numerical stability, the Cholesky decomposition is used to solve least squares, optimization, and state estimation problems.
 
 However, the Cholesky decomposition is only applicable to Hermitian positive definite matrices. 
-A matrix $A$ is positive definite if  $\mathbf{z}^TA\mathbf{z} > 0$ for all $\mathbf{z} \neq 0$. 
-Furthermore, $A$ is Hermitian if $A = A^*$ where $A^* = \overline{A^T}$, so a real Hermitian matrix is just a symmetric matrix. 
+A matrix $A$ is positive definite if  $\mathbf{z}\trp A\mathbf{z} > 0$ for all $\mathbf{z} \neq 0$. 
+Furthermore, $A$ is Hermitian if $A = A^*$ where $A^* = \overline{A\trp }$, so a real Hermitian matrix is just a symmetric matrix. 
 The Cholesky decomposition is the matrix equivalent to taking the square root of a positive real number.
 
 The Cholesky decomposition of a $A$ is a lower-triangular matrix $L$ such that
@@ -501,7 +501,7 @@ To calculate the green entry, you need to know each of the light gray entries.}
 
 \begin{problem}[Optional]
 Write a function that finds the Cholesky decomposition of a Hermitian positive definite matrix.
-Hint: To generate symmetric positive definite matrices on which to test your function, recall that for any matrix $A$, the matrix $A^TA$ is symmetric and positive definite.
+Hint: To generate symmetric positive definite matrices on which to test your function, recall that for any matrix $A$, the matrix $A\trp A$ is symmetric and positive definite.
 \end{problem}
 
 The \li{linalg} module of SciPy includes an optimized Cholesky decomposition. 

--- a/Labs/AffineTransformations/AffineTransformations.tex
+++ b/Labs/AffineTransformations/AffineTransformations.tex
@@ -333,19 +333,19 @@ We have the following algorithm for the LU decomposition, assuming it exists.
 \begin{algorithm}
 \begin{algorithmic}[1]
 \Procedure{LU Decomposition}{$A$}
-\State $m, n \gets \text{shape} \left( A \right)$ 
-\State $U \gets \text{copy} \left( A \right)$
-\State $L \gets I_n$
-\For{$0 \leq j < n$}
-    \For{$j+1 \leq i < m$}
-    \State $L_{[i,j]} \gets U_{[i, j]}/U_{[j, j]}$
-    \State $U_{[i,j:]} \gets U_{[i,j:]} - L_{[i,j]}U_{[j, j:]}$
+\State $m, n \gets \shape{A}$ 
+\State $U \gets \makecopy{A}$
+\State $L \gets \Id{n}$
+\For{$j=0 \ldots n-1$}
+    \For{$i=j+1 \ldots m-1$}
+    \State $L[i,j] \gets U[i, j]/U[j, j]$
+    \State $U[i,j:] \gets U[i,j:] - L[i,j]U[j, j:]$
 	\EndFor
 \EndFor
 \State \pseudoli{return} $L, U$
 \EndProcedure
 \end{algorithmic}
-\caption{The algorithm for LU decomposition. This algorithm returns lower triangular $L$ and upper triangular $U$ such that $A = LU$.}
+\caption{The algorithm for LU decomposition of a matrix $A$. This algorithm returns lower triangular $L$ and upper triangular $U$ such that $A = LU$.}
 \label{Alg:gram_schmidt}
 \end{algorithm}
 

--- a/Labs/ArnoldiIteration/arnoldi_iteration.tex
+++ b/Labs/ArnoldiIteration/arnoldi_iteration.tex
@@ -100,26 +100,27 @@ form.
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-\Procedure{arnoldi}{$b, A, k, tol$}
-	\State $Q \gets \text{empty}\left(b.size, k+1\right)$	\Comment{Some initialization steps}
-	\State $H \gets \text{zeros}\left( k+1, k\right)$
-	\State $Q_{[:,0]} = b/\|b\|_2$							
-	\For{$j=0$, $j<k$}							\Comment{Perform the actual iteration.}
-		\State $Q_{[:,j+1]} = AQ_{[:,j]}$		
-		\For{$i=0$, $i<j+1$}					\Comment{Modified Gram-Schmidt.}
-			\State $H_{[i,j]} = \langle Q_{[:,i]}, Q_{[:,j+1]}\rangle$		
-			\State $Q_{[:,j+1]} -= H_{[i,j]} Q_{[:,i]}$
+\Procedure{Arnoldi}{$\b, A, k, tol$}
+	\State $Q \gets \allocate{\size{\b}}{k+1}$			\Comment{Some initialization steps}
+	\State $H \gets \zeros{ k+1}{ k}$
+	\State $Q[:,0] \gets \b/\norm{\b}_2$							
+	\For{$j=0\ldots k-1$}							\Comment{Perform the actual iteration.}
+		\State $Q[:,j+1] \gets AQ[:,j]$		
+		\For{$i=0\ldots j$}					\Comment{Modified Gram-Schmidt.}
+			\State $H[i,j] \gets Q[:,i]\trp Q[:,j+1]$		
+			\State $Q[:,j+1] \gets Q[:,j+1] - H[i,j] Q[:,i]$
 		\EndFor
-		\State $H_{[j+1,j]} = \|Q_{[:,j+1]}\|_2$			\Comment{Set subdiagonal element of $H$.}
-            \If{$|H_{[j+1,j]}|<tol$}					\Comment{Stop if $\|Q_{[:,j+1]}\|_2$ is too small.}
-			\State \pseudoli{return} $H_{[:j+1,:j+1]}$, $Q_{[:,:j+1]}$
+		\State $H[j+1,j] \gets \norm{Q[:,j+1]}_2$			\Comment{Set subdiagonal element of $H$.}
+            \If{$|H[j+1,j]|<tol$}					\Comment{Stop if $\norm{Q[:,j+1]}_2$ is too small.}
+			\State \pseudoli{return} $H[:j+1,:j+1]$, $Q[:,:j+1]$
 		\EndIf
-		\State $Q_{[:,j+1]} /= H_{[j+1,j]}$				\Comment{Normalize $q_{j+1}$.}
+		\State $Q[:,j+1] \gets Q[:,j+1]/H[j+1,j]$				\Comment{Normalize $\q_{j+1}$.}
 	\EndFor
-	\State \pseudoli{return} $H_{[:-1, :]}$, $Q$			\Comment{Return $H_{k}$.}
+	\State \pseudoli{return} $H[:-1, :]$, $Q$			\Comment{Return $H_{k}$.}
 \EndProcedure
 \end{algorithmic}
-\caption{The Arnoldi Iteration. This algorithm operates on a vector $b$ of length $n$ and an $n \times n$ matrix $A$. It iterates $k$ times or until the norm of the next vector in the iteration is less than $tol$.}
+\caption{The Arnoldi Iteration. This algorithm accepts a square matrix $A$ and starting vector $\b$. It iterates $k$ times or until the norm of the next vector in the iteration is less than $tol$.
+The algorithm returns upper Hessenberg $H$ and orthonormal $Q$ such that $H = Q^{\mathsf{H}}AQ$.}
 \label{alg:arnoldi_iteration}
 \end{algorithm}
 
@@ -193,7 +194,7 @@ Let $Q_k$ be the matrix whose columns $\q_1, \ldots, \q_k$ are the orthonormal b
 let $H_k$ be the $k\times k$ upper Hessenburg matrix defined at the $k^{th}$ stage of the algorithm.
 Then these matrices satisfy
 \begin{equation}\label{equ:hqa}
-H_k = Q_k^* A Q_k.
+H_k = Q_k^{\mathsf H} A Q_k.
 \end{equation}
 If $k<n$ then $H_k$ is a low-rank approximation to $A$.
 We may use its eigenvalues as approximations to the eigenvalues of $A$.
@@ -392,27 +393,26 @@ The Lanczos iteration is found in Algorithm \ref{alg:lanczos_iteration}.
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-\Procedure{lanczos}{$b, A, k, tol$}
-	\State $q_0 \gets zeros(b.size)$								\Comment{Some initialization}
-	\State $q_1 \gets b/\|b\|_2$
-	\State $\alpha \gets \text{empty}\left(k\right)$
-	\State $\beta \gets \text{empty}\left(k\right)$
-	\State $\beta_{k} = 0$
-	\For{$i=0$, $i<k$}									\Comment{Perform the iteration.}
-		\State $z \gets Aq_1$					\Comment{$z$ is a temporary vector to store $q_{i+1}$.}
-		\State $\alpha_{i} = \langle q_1, z \rangle$				\Comment{$q_1$ is used to store the previous $q_i$.}
-		\State $z -= \alpha_i q_1 + \beta_{i-1} q_0$				\Comment{$q_0$ is used to store $q_{i-1}$.}
-		\State $\beta_{i} = \|z\|_2$						\Comment{Initialize $\beta_i$.}
-		\If{$\beta_i<tol$}								\Comment{Stop if $\|q_{i+1}\|_2$ is too small.}
-			\State \pseudoli{return} $\alpha_{[: i+1]}$, $\beta_{[: i]}$
+\Procedure{Lanczos}{$\b, A, k, tol$}
+	\State $\q_0 \gets \zeros{\size{\b}}$								\Comment{Some initialization}
+	\State $\q_1 \gets \b/\norm{\b}_2$
+	\State $\x \gets \allocate{k}$
+	\State $\y \gets \allocate{k}$
+	\For{$i=0\ldots k-1$}									\Comment{Perform the iteration.}
+		\State $\z \gets A\q_1$					\Comment{$\z$ is a temporary vector to store $\q_{i+1}$.}
+		\State $\x[i] \gets \q_1\trp \z$				\Comment{$\q_1$ is used to store the previous $\q_i$.}
+		\State $\z \gets \z - \x[i] \q_1 + \y[i-1] \q_0$				\Comment{$\q_0$ is used to store $\q_{i-1}$.}
+		\State $\y[i] = \norm{\z}_2$						\Comment{Initialize $\y[i]$.}
+		\If{$\y[i]<tol$}								\Comment{Stop if $\norm{ \q_{i+1}}_2$ is too small.}
+			\State \pseudoli{return} $\x[: i+1]$, $\y[: i]$
 		\EndIf
-		\State $z /= \beta_i$
-		\State $q_0, q_1 = q_1, z$						\Comment{Store new $q_{i+1}$ and $q_i$ on top of $q_1$ and $q_0$.}
+		\State $\z = \z/ \y[i]$
+		\State $\q_0, \q_1 = \q_1, \z$						\Comment{Store new $\q_{i+1}$ and $\q_i$ on top of $\q_1$ and $\q_0$.}
 	\EndFor
-	\State \pseudoli{return} $\alpha$, $\beta_{[: -1]}$
+	\State \pseudoli{return} $\x$, $\y[: -1]$
 \EndProcedure
 \end{algorithmic}
-\caption{The Lanczos Iteration. This algorithm operates on a vector $b$ of length $n$ and an $n \times n$ symmetric matrix $A$. It iterates $k$ times or until the norm of the next vector in the iteration is less than $tol$. It returns two vectors $\alpha$ and $\beta$ that respectively contain the main diagonal and first subdiagonal of the current Hessenberg approximation.}
+\caption{The Lanczos Iteration. This algorithm operates on a vector $\b$ of length $n$ and an $n \times n$ symmetric matrix $A$. It iterates $k$ times or until the norm of the next vector in the iteration is less than $tol$. It returns two vectors $\x$ and $\y$ that respectively contain the main diagonal and first subdiagonal of the current Hessenberg approximation.}
 \label{alg:lanczos_iteration}
 \end{algorithm}
 

--- a/Labs/GMRES/GMRES.tex
+++ b/Labs/GMRES/GMRES.tex
@@ -140,22 +140,23 @@ For a complete derivation see [TODO: ref textbook].
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-\Procedure{GMRES}{$A, b, k, tol$}
-	\State $Q \gets \text{empty}\left(b.size, k+1\right)$			\Comment{Initialize}
-	\State $H \gets \text{zeros}\left(k+1, k\right)$
-	\State $Q_{[:,0]} = b/\|b\|_2$
-    \For{$n=1,2,\ldots, k$}
+\Procedure{GMRES}{$A, \b, k, tol$}
+	\State $Q \gets \empty{\size{\b}}{k+1}$			\Comment{Initialize}
+	\State $H \gets \zeros{k+1}{ k}$
+	\State $Q[:,0] = \b/\norm{\b}_2$
+    \For{$n=1\ldots k$}
         \State Set entries of $Q$ and $H$ as in Arnoldi iteration
-        \State Calculate least squares solution $y$ of \ref{eq:GMRES_lstsq2}.
+        \State Calculate least squares solution $\y$ of \ref{eq:GMRES_lstsq2}.
         \State Calculate the residual $res$ given by Equation \ref{eq:GMRES_residual}.
         \If{$res < tol$}
-            \State \pseudoli{return} $Q_{[:,n+1]}y, \,\, res$
+            \State \pseudoli{return} $Q[:,n+1]\y, \,\, res$
         \EndIf
     \EndFor
-    \State \pseudoli{return} $Q_{[:,n+1]}y, \,\, res$						
+    \State \pseudoli{return} $Q[:,n+1]\y, \,\, res$						
 \EndProcedure
 \end{algorithmic}
-\caption{The GMRES algorithm. This algorithm operates on a vector $b$ of length $m$ and an $m \times m$ matrix $A$. It iterates $k$ times or until the residual is less than $tol$.}
+\caption{The GMRES algorithm. This algorithm operates on a vector $\b$ and matrix $A$. 
+It iterates $k$ times or until the residual is less than $tol$, returning an approximate solution to $A\x=\b$ and the error in this approximation.}
 \label{alg:gmres}
 \end{algorithm}
 
@@ -331,20 +332,21 @@ GMRES with restarts is outlined in Algorithm \ref{alg:gmres_k}.
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-\Procedure{GMRES(k)}{$A, b, k, tol, restarts$}
+\Procedure{GMRES(k)}{$A, \b, k, tol, restarts$}
   \State $r \gets 0$ \Comment{Restart counter}
-  \State $Q \gets \text{empty}\left(b.size, k+1\right)$			\Comment{Initialize}
-\State $H \gets \text{zeros}\left(k+1, k\right)$
+  \State $Q \gets \empty{\size{b}}{k+1}$			\Comment{Initialize}
+\State $H \gets \zeros{k+1}{ k}$
    \While{$r \leq restarts$}
-	\State{ Perform the GMRES algorithm, obtaining a least squares solution $y$}
+	\State{ Perform the GMRES algorithm, obtaining a least squares solution $\y$}
 	\State{ If the desired tolerance was reached, return. Otherwise, continue.}
-    \State $b \gets Q_{[:,k+1]}y$
+    \State $b \gets Q[:,k+1]\y$
     \State $r \gets r+1$
     \EndWhile
-    \State \pseudoli{return} $Q_{[:,k+1]}y, \,\, res$		\Comment{Return the approximate solution and the residual}
+    \State \pseudoli{return} $Q[:,k+1]\y, \,\, res$		\Comment{Return the approximate solution and the residual}
 \EndProcedure
 \end{algorithmic}
-\caption{The GMRES(k) algorithm. This algorithm performs GMRES on a vector $b$ of length $m$ and an $m \times m$ matrix $A$. It iterates $k$ times before restarting. It returns after $restarts$ restarts or when the residual is less than $tol$. }
+\caption{The GMRES(k) algorithm. This algorithm performs GMRES on a vector $\b$ and matrix $A$. It iterates $k$ times before restarting. 
+It terminates after $restarts$ restarts or when the residual is less than $tol$, returning an approximate solution to $A\x=\b$ and the error in this approximation. }
 \label{alg:gmres_k}
 \end{algorithm}
 

--- a/Labs/GivensRotations/Givens.tex
+++ b/Labs/GivensRotations/Givens.tex
@@ -8,7 +8,7 @@ We can use the same strategy to compute the QR decomposition with rotations inst
 \section*{Givens rotations}
 
 Let us begin with Givens rotations in $\mathbb{R}^2$. 
-An arbitrary vector $\x = (a, b)^T$ can be rotated into the span of $e_1$ via an orthogonal transformation. 
+An arbitrary vector $\x = (a, b)\trp$ can be rotated into the span of $e_1$ via an orthogonal transformation. 
 In fact, the matrix $T_{\theta} = \begin{pmatrix}\cos \theta & - \sin \theta \\ \sin \theta & \cos \theta \end{pmatrix}$ rotates a vector counterclockwise by $\theta$.
 Thus, if $\theta$ is the clockwise-angle between $\x$ and $e_1$, the vector $T_{-\theta}\x$ will be in the span of $e_1$.
 We can find $\sin \theta$ and $\cos \theta$ with the formulas $\sin = \frac{\text{opp}}{\text{hyp}}$ and $\cos = \frac{\text{adj}}{\text{hyp}}$, so $\sin \theta = \frac{b}{\sqrt{a^2+b^2}}$ and $\cos \theta =  \frac{a}{\sqrt{a^2+b^2}}$ (see Figure\ref{fig:angle}).
@@ -31,7 +31,7 @@ T_{-\theta}\x = \begin{pmatrix}\cos \theta &  \sin \theta \\ -\sin \theta & \cos
 	end angle=-20, radius=4.5pt];
 \node[draw=none](theta)at(.8, .15){$\theta$};
 \end{tikzpicture}
-\caption{Rotating clockwise by $\theta$ will send the vector $(a,b)^T$ to the span of $e_1$.}
+\caption{Rotating clockwise by $\theta$ will send the vector $(a,b)\trp$ to the span of $e_1$.}
 \label{fig:angle}
 \end{center}
 \end{figure}
@@ -166,21 +166,22 @@ Assuming that at the $ij^{th}$ stage of the algorithm, $a_{ij}$ is nonzero, Algo
 
 \begin{algorithm}
 \begin{algorithmic}[1]
-\caption{Givens Triangularization. Return an orthogonal matrix $Q$ and an upper triangular matrix $R$ satisfying $A = QR$.}
+\caption{Givens triangularization. Return an orthogonal matrix $Q$ and an upper triangular matrix $R$ satisfying $A = QR$.}
 \label{Alg:givens}
 \Procedure{Givens Triangularization}{$A$}
-\State $R \gets \text{copy}(A)$
-\State $Q \gets I_A$
-\State $G \gets \text{empty}((2,2))$
-\For{$0\leq j < n$}
-    \For{$ m \geq i > j$}
-      \State $a, b \gets R_{i-1,j}, R_{i,j}$
+\State $m, n \gets \shape{A}$
+\State $R \gets \makecopy{A}$
+\State $Q \gets \Id{m}$
+\State $G \gets \allocate{2}{2}$
+\For{$j=0\ldots n-1$}
+    \For{$i=m\ldots j+1$}
+      \State $a, b \gets R[i-1,j], R[i,j]$
       \State $G \gets [[a, b],[-b,a]]/\sqrt{a^2+b^2}$
-      \State $R_{i-1:i+1, j:} = GR_{i-1:i+1, j:}$
-      \State $Q_{i-1:i+1,:} = GQ_{i-1:i+1,:}$
+      \State $R[i-1:i+1, j:] \gets GR[i-1:i+1, j:]$
+      \State $Q[i-1:i+1,:] \gets GQ[i-1:i+1,:]$
     \EndFor
 \EndFor
-\State \pseudoli{return} $Q^T, R$
+\State \pseudoli{return} $Q\trp , R$
 \EndProcedure
 \end{algorithmic}
 \end{algorithm}
@@ -192,7 +193,7 @@ An interesting side-note is that each Givens rotation can be represented as a si
 A similar approach would to store Householder reflectors in the columns they zero out.
 In either case, we can represent the QR decomposition of an array using only the memory that was originally used to store the array itself.
 This is similar to the approach  for computing the LU decomposition entirely in place.
-These representations of $Q$ and $R$ can be used in various ways to perform matrix multiplication by $Q$, $Q^T$ and $R$ as needed.
+These representations of $Q$ and $R$ can be used in various ways to perform matrix multiplication by $Q$, $Q\trp$ and $R$ as needed.
 \end{comment}
 
 
@@ -235,7 +236,7 @@ These representations of $Q$ and $R$ can be used in various ways to perform matr
 
   \end{itemize}
 
-\item Return $Q^T$ and $R$.
+\item Return $Q\trp$ and $R$.
 
 \end{itemize}
 \end{comment}
@@ -253,7 +254,7 @@ Assume that at the $ij^{th}$ stage of the algorithm, $a_{ij}$ will be nonzero.
 Modify your solution to Problem \ref{prob:Givens} to compute the Givens triangularization of an upper Hessenberg matrix, making the following changes:
 \begin{enumerate}
 \item Iterate through the first subdiagonal from left to right. (These are the only entries that need to be zeroed out.)
-\item Line 10 of Algorithm \ref{Alg:givens} updates $Q$ with the current Givens rotation $G$. Decrease the number of entries of $Q$ that are modified in this line. Do this by replacing $Q_{i-1:i+1, :}$ with $Q_{i-1:i+1, :k_i}$ where $k_i$ is some appropriately chosen number (dependent on $i$) such that $Q_{i-1:i+1, k_i:}=0$.
+\item Line 10 of Algorithm \ref{Alg:givens} updates $Q$ with the current Givens rotation $G$. Decrease the number of entries of $Q$ that are modified in this line. Do this by replacing $Q[i-1:i+1, :]$ with $Q[i-1:i+1, :k_i]$ where $k_i$ is some appropriately chosen number (dependent on $i$) such that $Q[i-1:i+1, k_i:]=0$.
 \end{enumerate}
 Hint: Here is how to generate a random upper Hessenberg matrix on which to test your function.
 The idea is to generate a random matrix and then zero out all entries below the first subdiagonal.
@@ -292,7 +293,7 @@ Notice that you will have to apply each Givens rotation across the full width of
 For around what size of matrices is direct multiplication by $Q$ slower than this method of multiplying by $Q$?
 For timing purposes, make a random upper Hessenberg matrix, compute its QR decomposition using the function you just wrote and your solution to Problem \ref{prob:givens_hessenberg}, then time how long it takes to left multiply a random square array by $Q$ using the function you just wrote and the \li{dot} method of NumPy arrays.
 
-Note: the functions you just wrote can be used to perform right multiplication as well since $B Q = \left(Q^T B^T \right)^T$ and $B Q^T = \left( Q B^T \right)^T$.
+Note: the functions you just wrote can be used to perform right multiplication as well since $B Q = \left(Q\trp B\trp \right)\trp$ and $B Q\trp = \left( Q B\trp \right)\trp$.
 \end{problem}
 \end{comment}
 
@@ -303,7 +304,7 @@ Note: the functions you just wrote can be used to perform right multiplication a
 A linear system $A\x=\b$ is \emph{overdetermined} if it has no solutions. 
 In this situation, the \emph{least squares solution} is a vector $\widehat{\x}$ hat is ``closest'' to a solution. 
 By definition, $\widehat{\x}$ is the vector such that $A\widehat{\x}$ will equal the projection of $\b$ onto the range of $A$. 
-We can compute $\widehat{\x}$ by solving the \emph{Normal Equation} $A^HA\widehat{\x} = A^H\b$ (see [TODO: ref textbook] for a derivation of the Normal Equation).
+We can compute $\widehat{\x}$ by solving the \emph{Normal Equation} $A\trp A\widehat{\x} = A\trp \b$ (see [TODO: ref textbook] for a derivation of the Normal Equation).
 
 
 \subsection*{Solving the normal equation}
@@ -313,8 +314,8 @@ In many applications, $A$ is usually full rank, including when least squares is 
 Let $A=QR$ be the QR decomposition of $A$, so $R = \left(\begin{array}{c}R_0\\
 0\\ \end{array} \right)$
 where $R_0$ is $n \times n$, nonsingular, and upper triangular. 
-It can be shown that $\widehat{x}$ is the least squares solution to $Ax=b$ if and only if $R_0\widehat{x} = (Q^Tb)_{[:n]}.$ 
-Here, $(Q^Tb)_{[:n]}$ refers to the first $n$ rows of $Q^Tb$.
+It can be shown that $\widehat{\x}$ is the least squares solution to $A\x=\b$ if and only if $R_0\widehat{\x} = (Q\trp \b)[:n].$ 
+Here, $(Q\trp \b)[:n]$ refers to the first $n$ rows of $Q\trp \b$.
 Since $R$ is upper triangular, we can solve this equation quickly with back substitution. 
 
 

--- a/Labs/QR/QR.tex
+++ b/Labs/QR/QR.tex
@@ -61,21 +61,21 @@ The entire modified Gram-Schmidt algorithm is described in Algorithm \ref{Alg:gr
 \begin{algorithm}
 \begin{algorithmic}[1]
 \Procedure{Modified Gram-Schmidt}{$A$}
-\State $m, n \gets \text{shape} \left( A \right)$
-\State $Q \gets \text{copy} \left( A \right)$
-\State $R \gets \text{zeros}((n,n))$
-\For{$0 \leq i < n$}
-    \State $R_{i,i} \gets \norm{Q_{:,i}}$
-    \State $Q_{:,i} \gets Q_{:,i}/R_{i,i}$
-    \For{$i+1 \leq j < n$}
-        \State $R_{i,j} \gets Q_{:,j}^\mathsf{T}Q_{:,i}$
-        \State $Q_{:,j} \gets Q_{:,j}-R_{i,j}Q_{:,i}$
+\State $m, n \gets \shape{A}$
+\State $Q \gets \makecopy{A}$
+\State $R \gets \zeros{n}{n}$
+\For{$i=0\ldots n-1$}
+    \State $R[i,i] \gets \norm{Q[:,i]}$
+    \State $Q[:,i] \gets Q[:,i]/R[i,i]$
+    \For{$j=i+1\ldots n-1$}
+        \State $R[i,j] \gets Q[:,j]\trp  Q[:,i]$
+        \State $Q[:,j] \gets Q[:,j]-R[i,j]Q[:,i]$
 	\EndFor
 \EndFor
 \State \pseudoli{return} $Q, R$
 \EndProcedure
 \end{algorithmic}
-\caption{The modified Gram-Schmidt. This algorithm returns orthogonal $Q$ and upper triangular $R$ such that $A = QR$.}
+\caption{The modified Gram-Schmidt algorithm. This algorithm returns orthogonal $Q$ and upper triangular $R$ such that $A = QR$.}
 \label{Alg:gram_schmidt}
 \end{algorithm}
 
@@ -137,8 +137,8 @@ See Figure \ref{fig:Householder_reflector}.
 
 A \emph{Householder transformation} of $\mathbb{R}^n$ is a linear transformation that reflects about a hyperplane. 
 If a hyperplane $H$ has normal vector $\mathbf{v}$, let $\mathbf{u} = \mathbf{v}/\|\mathbf{v}\|$. 
-Then the Householder transformation that reflects about $H$ corresponds to the matrix $H_{\mathbf{u}} = I - 2 \mathbf{u}\mathbf{u}^T$. 
-You can check that $(I - 2 \mathbf{u}\mathbf{u}^T)^T(I - 2 \mathbf{u}\mathbf{u}^T)=I$, so Householder transformations are orthogonal.
+Then the Householder transformation that reflects about $H$ corresponds to the matrix $H_{\mathbf{u}} = I - 2 \mathbf{u}\mathbf{u}\trp$. 
+You can check that $(I - 2 \mathbf{u}\mathbf{u}\trp)\trp(I - 2 \mathbf{u}\mathbf{u}\trp)=I$, so Householder transformations are orthogonal.
 
 %\newcommand{\ipt}[2]{\ensuremath{\left\langle #1,#2 \right\rangle}}
 \begin{figure}
@@ -170,7 +170,7 @@ The Householder transformation $H_{\mathbf{v}}$ of $\mathbf{x}$ is just the refl
 The QR decomposition of an $m \times n$ matrix $A$ can also be computed with Householder transformations via the Householder triangularization.
 Whereas Gram-Schmidt makes $A$ \emph{orthonormal} using a series of transformations stored in an \emph{upper triangular} matrix, Householder triangularization makes $A$ \emph{triangular} by a series of \emph{orthonormal} transformations.
 More precisely, the Householder triangularization finds an $m \times m$ orthogonal matrix $Q$ and and $m \times n$ upper triangular matrix $R$ such that $QA = R$. 
-Since $Q$ is orthogonal, $Q^{-1}=Q^T$ so $A = Q^TR$, and we have discovered the QR decomposition.
+Since $Q$ is orthogonal, $Q^{-1}=Q\trp$ so $A = Q\trp R$, and we have discovered the QR decomposition.
 
 Let's demonstrate the idea behind Householder triangularization on a $4 \times 3$ matrix $A$.
 Let $e_1, \ldots, e_4$ be the standard basis of $\mathbb{R}^4$.
@@ -282,42 +282,42 @@ As we have already discussed, $Q_k$ fixes the first $k-1$ rows and columns of an
 In fact, if $\x'' = (0, \ldots, 0, x_k, x_{k+1}, \ldots, x_n)$ as above, then $\mathbf{v}_k = (0, \ldots, 0, v_{k_0}, x_{k+1}, \ldots, x_n)$ where $v_{k_0} = x_k + \sign(x_k) \| \x'' \|$. 
 If $\mathbf{u}_k$ is the normalization of $(v_{k_0}, x_{k+1}, \ldots, x_n) \in \mathbb{R}^{n-(k-1)}$, then
 \[
-Q_k = I-\frac{2\x''(\x'')^T}{\|\x''\|^2} =  \begin{pmatrix}
+Q_k = I-\frac{2\x''(\x'')\trp}{\|\x''\|^2} =  \begin{pmatrix}
 I & 0 \\
-0 & I-2\mathbf{u}_k\mathbf{u}_k^T
+0 & I-2\mathbf{u}_k\mathbf{u}_k\trp
 \end{pmatrix}.
 \]
 This means that, using block multiplication,
 \[
 Q_kA_k =  \begin{pmatrix}
 I & 0 \\
-0 & I-2\mathbf{u}_k\mathbf{u}_k^T
+0 & I-2\mathbf{u}_k\mathbf{u}_k\trp
 \end{pmatrix}\begin{pmatrix}
 T & X' \\
 0 & X''
 \end{pmatrix} = \begin{pmatrix}
 T & X' \\
-0 & ( I-2\mathbf{u}_k\mathbf{u}_k^T)X''
+0 & ( I-2\mathbf{u}_k\mathbf{u}_k\trp)X''
 \end{pmatrix}.
 \]
-So at each stage of the algorithm, we only need to update the entries in the bottom right submatrix of $A_k$, and these change via matrix multiplication by $ I-2\mathbf{u}_k\mathbf{u}_k^T$. Similarly,
+So at each stage of the algorithm, we only need to update the entries in the bottom right submatrix of $A_k$, and these change via matrix multiplication by $ I-2\mathbf{u}_k\mathbf{u}_k\trp$. Similarly,
 \[
 Q_kQ_{k-1}\ldots Q_1 = Q_k \begin{pmatrix}
 A\\
 B
 \end{pmatrix} = \begin{pmatrix}
 I & 0 \\
-0 & I-2\mathbf{u}_k\mathbf{u}_k^T
+0 & I-2\mathbf{u}_k\mathbf{u}_k\trp
 \end{pmatrix}\begin{pmatrix}
 A\\
 B
 \end{pmatrix} = \begin{pmatrix}
 A\\
-(I-2\mathbf{u}_k\mathbf{u}_k^T)B
+(I-2\mathbf{u}_k\mathbf{u}_k\trp)B
 \end{pmatrix},
 \]
 so to update $\prod Q_i$, we need only modify the bottom rows. 
-These also change via matrix multiplication by $I-2\mathbf{u}_k\mathbf{u}_k^T$.
+These also change via matrix multiplication by $I-2\mathbf{u}_k\mathbf{u}_k\trp$.
 
 These arguments produce Algorithm \ref{Alg:Householder}.
 
@@ -391,22 +391,22 @@ Reflecting about the hyperplane defined by $\v_i$ produces  $H_{\v_i}\x$.}
 
 %TODO: explain notation, fix algorithm
 \begin{algorithm}
-\caption{Householder triangularization. 
+\caption{The Householder triangularization algorithm. 
 This algorithm returns orthonormal $Q$ and upper triangular $R$ satisfying $A = QR$.}
 \label{Alg:Householder}
 \begin{algorithmic}[1]
 \Procedure{Householder}{$A$}
-\State $m, n \gets \text{shape} \left( A \right)$
-\State $R \gets \text{copy} \left( A \right)$
-\State $Q \gets I_m$
-\For{$0 \leq k < n-1$}
-    \State $u_k \gets \text{copy} \left( R_{k:,k} \right)$
-    \State $u_{k_0} \gets u_{k_0} + \text{sign} \left( u_{k_0} \right) \norm{u_k}$
-    \State $u_k \gets u_k / \norm{u_k}$
-    \State $R_{k:,k:} \gets R_{k:,k:} - 2 u_k \left( u_k^\mathsf{T} R_{k:,k:} \right)$
-    \State $Q_{k:} \gets Q_{k:} - 2 u_k \left( u_k^\mathsf{T} Q_{k:} \right)$
+\State $m, n \gets \shape{A}$
+\State $R \gets \makecopy{A}$
+\State $Q \gets \Id{m}$
+\For{$k=0\ldots n-2$}
+    \State $\u \gets \makecopy{R[k:,k]}$
+    \State $\u[0] \gets \u[0] + \sign( \u[0] ) \norm{\u}$
+    \State $\u \gets \u / \norm{\u}$
+    \State $R[k:,k:] \gets R[k:,k:] - 2 \u \left(\u\trp R[k:,k:] \right)$
+    \State $Q[k:] \gets Q[k:] - 2 \u \left( \u\trp Q[k:] \right)$
 \EndFor
-\State \pseudoli{return} $Q^\mathsf{H}, R$
+\State \pseudoli{return} $Q\trp, R$
 \EndProcedure
 \end{algorithmic}
 \end{algorithm}
@@ -483,19 +483,19 @@ However, MGS is still useful for some types of iterative methods because it find
 
 \section*{Upper Hessenberg form}
 An upper Hessenberg matrix is a square matrix with zeros below the first subdiagonal.
-Every  $n \times n$ matrix $A$ can be written $A = Q^THQ$ where $Q$ is orthonormal and $H$ is an upper Hessenberg matrix, called the Hessenberg form of $A$.
+Every  $n \times n$ matrix $A$ can be written $A = Q\trp HQ$ where $Q$ is orthonormal and $H$ is an upper Hessenberg matrix, called the Hessenberg form of $A$.
 
 A fast algorithm for computing the QR decomposition of a Hessenberg matrix will be taught in Lab \ref{lab:givens}. This algorithm in turn leads to a fast algorithm for finding eigenvalues of a matrix, which will be discussed in Lab \ref{lab:EigSolve}.
 
 For now, we will outline an algorithm for computing the upper Hessenberg form of any matrix. 
 Like Householder triangularization, this algorithm uses Householder transformations.
-To find orthogonal $Q$ and upper Hessenberg $H$ such that $A = Q^THQ$, it suffices to find such matrices that satisfy $Q^TAQ=H$. 
+To find orthogonal $Q$ and upper Hessenberg $H$ such that $A = Q\trp HQ$, it suffices to find such matrices that satisfy $Q\trp AQ=H$. 
 Thus, our strategy is to multiply $A$ on the right and left by a series of orthonormal matrices until it is in Hessenberg form.
 If we use the same $Q_1$ as in the first step of the Householder algorithm, then with $Q_1 A$ we introduce zeros in the first column of $A$.
-However, since we now have to multiply $Q_1 A$ on the left by $Q_1^T$, all those zeros are destroyed.
+However, since we now have to multiply $Q_1 A$ on the left by $Q_1\trp$, all those zeros are destroyed.
 
 Instead, let's try choosing a $Q_1$ that fixes $e_1$ and reflects the first column of $A$ into the span of $e_1$ and $e_2$. 
-Because $Q_1$ fixes $e_1$, the product $Q_1A$ leaves the first row of $A$ alone, and $(Q_1A)Q_1^T$ leaves the first column of $(Q_1A)$ alone.
+Because $Q_1$ fixes $e_1$, the product $Q_1A$ leaves the first row of $A$ alone, and $(Q_1A)Q_1\trp$ leaves the first column of $(Q_1A)$ alone.
 If $A$ is a $5 \times 5$ matrix, this looks like
 \[
 \begin{array}{ccccc}
@@ -514,7 +514,7 @@ If $A$ is a $5 \times 5$ matrix, this looks like
 0 & * & * & * & * \\
 0 & * & * & * & *
 \end{pmatrix}
-&\underrightarrow{\cdot Q_1^T }&
+&\underrightarrow{\cdot Q_1\trp }&
 \begin{pmatrix}
 * & * & * & * & * \\
 * & * & * & * & * \\
@@ -523,12 +523,12 @@ If $A$ is a $5 \times 5$ matrix, this looks like
 0 & * & * & * & *
 \end{pmatrix}
 \\
-A & & Q_1A & & (Q_1 A) Q_1^T
+A & & Q_1A & & (Q_1 A) Q_1\trp
   \end{array}
 \]
 We now iterate through the matrix until we obtain
 \begin{equation*}
-Q_3 Q_2 Q_1 A Q_1^T Q_2 ^T Q_3^T =
+Q_3 Q_2 Q_1 A Q_1\trp Q_2 \trp Q_3\trp =
 \begin{pmatrix}
 * & * & * & * & * \\
 * & * & * & * & * \\
@@ -544,21 +544,21 @@ Notice that this algorithm is very similar to Algorithm \ref{Alg:Householder}.
 
 
 \begin{algorithm}
-\caption{Reduction to Hessenberg form for a nonsingular matrix. 
-This algorithm returns orthogonal $Q$ and upper Hessenberg $H$ such that $A = Q^THQ$.}
+\caption{Algorithm for reducing a nonsingular matrix $A$ to Hessenburg form. 
+This algorithm returns orthogonal $Q$ and upper Hessenberg $H$ such that $A = Q\trp HQ$.}
 \label{Alg:Hessenberg}
 \begin{algorithmic}[1]
 \Procedure{Hessenberg}{$A$}
-\State $m, n \gets \text{shape}(A)$
-\State $H \gets \text{copy}(A)$
-\State $Q \gets I_m$
-\For{$0 \leq k < n-2$}
-    \State $u_k \gets \text{copy}\left(H_{k+1:, k}\right)$
-    \State $u_{k_0} \gets u_{k_0} + \text{sign}(u_{k_0}) \norm{u_k}$
-    \State $u_k \gets u_k/\norm{u_k}$
-    \State $H_{k+1:,k:} \gets H_{k+1:,k:} - 2u_k(u_k^\mathsf{T} H_{k+1:,k:})$
-    \State $H_{:,k+1:} \gets H_{:,k+1:} - 2(H_{:,k+1:} u_k) u_k^\mathsf{T}$
-    \State $Q_{k+1:} \gets Q_{k+1:} - 2u_k(u_k^\mathsf{T} Q_{k+1:})$
+\State $m, n \gets \shape{A}$
+\State $H \gets \makecopy{A}$
+\State $Q \gets \Id{m}$
+\For{$k=0 \ldots n-3$}
+    \State $\u \gets \text{copy}\left(H_{k+1:, k}\right)$
+    \State $\u[0] \gets \u[0] + \text{sign}(\u[0]) \norm{\u}$
+    \State $\u \gets \u/\norm{\u}$
+    \State $H[k+1:,k:] \gets H[k+1:,k:] - 2\u(\u\trp H[k+1:,k:])$
+    \State $H[:,k+1:] \gets H[:,k+1:] - 2(H[:,k+1:] \u) \u\trp$
+    \State $Q[k+1:] \gets Q[k+1:] - 2\u(\u\trp Q[k+1:])$
 \EndFor
 \State \pseudoli{return} $Q, H$
 \EndProcedure
@@ -566,7 +566,7 @@ This algorithm returns orthogonal $Q$ and upper Hessenberg $H$ such that $A = Q^
 \end{algorithm}
 
 When $A$ is symmetric, its upper Hessenberg form is a tridiagonal matrix. 
-This is because the $Q_i$'s zero out everything below the first subdiagonal of $A$ and the $Q_i^T$'s zero out everything above the first superdiagonal.
+This is because the $Q_i$'s zero out everything below the first subdiagonal of $A$ and the $Q_i\trp$'s zero out everything above the first superdiagonal.
 Thus, the Hessenberg form of a symmetric matrix is especially useful, since as we saw in Lab \ref{lab:complexity}, tridiagonal matrices make computations fast.
 
 
@@ -575,7 +575,7 @@ Thus, the Hessenberg form of a symmetric matrix is especially useful, since as w
 %TODO: This doesn't work if $A$ is singular
 \begin{problem}
 \label{prob:hessenberg}
-Write a function that accepts as input a nonsingular square matrix $A$ and computes its Hessenberg form, returning orthogonal $Q$ and upper Hessenberg $H$ satisfying $A = Q^THQ$. 
+Write a function that accepts as input a nonsingular square matrix $A$ and computes its Hessenberg form, returning orthogonal $Q$ and upper Hessenberg $H$ satisfying $A = Q\trp HQ$. 
 Your function should use Algorithm \ref{Alg:hessenberg}. 
 What happens when you compute the Hessenberg factorization of a symmetric matrix?
 \end{problem}

--- a/Vol1.tex
+++ b/Vol1.tex
@@ -27,6 +27,7 @@
 \usepackage{mathtools}
 \usepackage{tikz}
 \usetikzlibrary{trees, shapes, arrows, backgrounds, positioning}
+\usepackage{xparse}
 
 \input{command}
 

--- a/command.tex
+++ b/command.tex
@@ -227,7 +227,7 @@
 \providecommand{\set}[1]{\lbrace#1\rbrace}
 \providecommand{\setconstruct}[2]{\lbrace#1:#2\rbrace}
 \providecommand{\Res}[1]{\underset{#1}{Res}}           % Residue
-\newcommand{\trans}[1]{{#1}^{\mathrm T}}				% TODO: insert transpose used in the textbook
+\newcommand{\trp}{^{\mathsf T}} %matrix transpose
 
 \newcommand{\ipt}[2]{\langle #1,#2 \rangle}
 \newcommand{\ip}{\int_{-\infty}^{+\infty}}

--- a/command.tex
+++ b/command.tex
@@ -227,6 +227,7 @@
 \providecommand{\set}[1]{\lbrace#1\rbrace}
 \providecommand{\setconstruct}[2]{\lbrace#1:#2\rbrace}
 \providecommand{\Res}[1]{\underset{#1}{Res}}           % Residue
+\newcommand{\trans}[1]{{#1}^{\mathrm T}}				% TODO: insert transpose used in the textbook
 
 \newcommand{\ipt}[2]{\langle #1,#2 \rangle}
 \newcommand{\ip}{\int_{-\infty}^{+\infty}}
@@ -234,8 +235,17 @@
 \renewcommand{\ker}[1]{\mathcal{N}(#1)}
 \newcommand{\ran}[1]{\mathcal{R}(#1)}
 
+%These commands are specifically for use in the pseudocode environment
+\newcommand{\allocate}[2]{\mathrm{empty}(#1, #2)}
+\newcommand{\Id}[1]{\mathrm{Id}(#1)}
+\newcommand{\zeros}[2]{\mathrm{zeros}(#1, #2)}
+\newcommand{\makecopy}[1]{\mathrm{copy}(#1)}
+\newcommand{\shape}[1]{\mathrm{shape}(#1)}
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Math Operators
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Many of these are for use in the pseudocode environments
 \DeclareMathOperator{\sign}{sign}
 \DeclareMathOperator{\sech}{sech}

--- a/command.tex
+++ b/command.tex
@@ -236,12 +236,23 @@
 \newcommand{\ran}[1]{\mathcal{R}(#1)}
 
 %These commands are specifically for use in the pseudocode environment
-\newcommand{\allocate}[2]{\mathrm{empty}(#1, #2)}
-\newcommand{\Id}[1]{\mathrm{Id}(#1)}
-\newcommand{\zeros}[2]{\mathrm{zeros}(#1, #2)}
-\newcommand{\makecopy}[1]{\mathrm{copy}(#1)}
-\newcommand{\shape}[1]{\mathrm{shape}(#1)}
+% Load the xparse package to use these commands
+\NewDocumentCommand\allocate{m+g}{		% Empty array
+  \IfNoValueTF{#2}
+    {\mathrm{empty}(#1)}					% 1 dimension
+    {\mathrm{empty}(#1, #2)}				% 2 dimensions
+}
 
+\NewDocumentCommand\zeros{m+g}{		% Zero array
+  \IfNoValueTF{#2}
+    {\mathrm{zeros}(#1)}
+    {\mathrm{zeros}(#1, #2)}%
+}
+
+\newcommand{\Id}[1]{\mathrm{Id}(#1)}		% Identity array
+\newcommand{\makecopy}[1]{\mathrm{copy}(#1)} % Copy an array
+\newcommand{\shape}[1]{\mathrm{shape}(#1)}	
+\newcommand{\size}[1]{\mathrm{size}(#1)}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Math Operators

--- a/notation_index.tex
+++ b/notation_index.tex
@@ -1,0 +1,40 @@
+\lab{Index of Pseudocode Notation}{Index of Notation}
+\label{notation_index}
+
+\section*{Objects}
+\renewcommand{\arraystretch}{1.3}
+\begin{tabular}{l l}
+$A$ 					& A capitol letter typically denotes a matrix, or 2-D NumPy array\\
+$[[a, b], [c, d]]$ 			& The explicit array $\left(\begin{array}{cc}
+a & b\\
+c & d\\\end{array}\right)$\\
+$A \gets \allocate{m}{n}$ 	& Allocate memory for an $m \times n$ NumPy array $A$\\
+$\Id{n}$	 			& The $n\times n$ array with 1's on the diagonal and 0's elsewhere \\
+$a$ 					& A lowercase letter typically denotes a scalar\\
+
+$A[:, j], \v[i]$ 			& Slice the 2-D array $A$ or 1-D array $\v$ as in Python\\
+$\v$ 					& A boldface letter typically denotes a vector, or 1-D NumPy array\\
+$\zeros{m}{n}$	 		& The $m\times n$ array of zeros 
+\end{tabular}
+
+\section*{Operations}
+\begin{tabular}{l l}
+$\makecopy{A}$		& Make a copy of the array $A$\\
+$A/a$, $\v/a$, $b/a$ 		& Divide by the scalar $a$\\
+$AB$, $aB$			& Multiply scalars or matrices\\
+$\| \v \|, \| \v \|_2$ 		& Find the (Euclidean) norm of $\v$\\
+$\shape{A}$			& Return the dimensions of the array $A$\\
+$\sign(a)$				& Return the sign of the scalar $a$\\
+$\trans{A}$				& Transpose the array $A$
+\end{tabular}
+
+\section*{Programming constructs}
+\begin{tabular}{p{5.5cm} p{8cm}}
+$\vartriangleright$		& Comment\\
+${\bf for}\; i=1 \ldots n\; {\bf do}$ & ``For'' loop. Iterate from 1 to $n$.\\
+$\gets$				& Assignment operator. If $a \gets b$ then $a$ is assigned the value of $b$.\\
+$\bf{if} \;\ldots\; \bf{else}$		& ``If'' construction with optional ``else''\\
+$\bf{Procedure}<${\sc Name}$>$(Parameters)		& Defines the start of the algorithm called $<${\sc Name}$>$ which accepts the specified parameters as inputs\\
+$\bf{while}$			& ``While'' construction\\
+$\bf{return}$			& End of algorithm. Return any values specified.
+\end{tabular}

--- a/notation_index.tex
+++ b/notation_index.tex
@@ -22,10 +22,10 @@ $\zeros{m}{n}$	 		& The $m\times n$ array of zeros
 $\makecopy{A}$		& Make a copy of the array $A$\\
 $A/a$, $\v/a$, $b/a$ 		& Divide by the scalar $a$\\
 $AB$, $aB$			& Multiply scalars or matrices\\
-$\| \v \|, \| \v \|_2$ 		& Find the (Euclidean) norm of $\v$\\
+$\norm{\v}, \norm{\v}_2$ 		& Find the (Euclidean) norm of $\v$\\
 $\shape{A}$			& Return the dimensions of the array $A$\\
 $\sign(a)$				& Return the sign of the scalar $a$\\
-$\trans{A}$				& Transpose the array $A$
+$A\trp$				& Transpose the array $A$
 \end{tabular}
 
 \section*{Programming constructs}

--- a/notation_index.tex
+++ b/notation_index.tex
@@ -8,13 +8,16 @@ $A$ 					& A capitol letter typically denotes a matrix, or 2-D NumPy array\\
 $[[a, b], [c, d]]$ 			& The explicit array $\left(\begin{array}{cc}
 a & b\\
 c & d\\\end{array}\right)$\\
-$A \gets \allocate{m}{n}$ 	& Allocate memory for an $m \times n$ NumPy array $A$\\
+$A \gets \allocate{m}{n}$, 
+$\v \gets \allocate{k}$ 	& Allocate memory for an $m \times n$ NumPy array $A$
+						or for a vector $\v$ of length $k$\\
 $\Id{n}$	 			& The $n\times n$ array with 1's on the diagonal and 0's elsewhere \\
 $a$ 					& A lowercase letter typically denotes a scalar\\
 
 $A[:, j], \v[i]$ 			& Slice the 2-D array $A$ or 1-D array $\v$ as in Python\\
 $\v$ 					& A boldface letter typically denotes a vector, or 1-D NumPy array\\
-$\zeros{m}{n}$	 		& The $m\times n$ array of zeros 
+$\zeros{m}{n}$,
+$\zeros{k}$	 		& The $m\times n$ array or length-$k$ vector of zeros 
 \end{tabular}
 
 \section*{Operations}
@@ -25,6 +28,7 @@ $AB$, $aB$			& Multiply scalars or matrices\\
 $\norm{\v}, \norm{\v}_2$ 		& Find the (Euclidean) norm of $\v$\\
 $\shape{A}$			& Return the dimensions of the array $A$\\
 $\sign(a)$				& Return the sign of the scalar $a$\\
+$\size{A}$				& Return the number of elements in the array $A$\\
 $A\trp$				& Transpose the array $A$
 \end{tabular}
 


### PR DESCRIPTION
This commit has

1. A file "notation_index.tex" in the main numerical_computing folder that is a sub-optimally formatted index to pseudocode notation. This file is not yet referenced from any Volume file, because I don't know the right way to add it in, but it should be.

2. New macros defined in command.tex for all relevant notations defined in notation_index.tex. We should always use these, because I imagine that in the next year or so we may want to tweak the notation.

3. xparse package added to the Volume 1 file (but not any other file). This is required by the new macros.

4. Updates to all the algorithms in Volume 4 so they use the macros and consistent notation (modulo typos).

Here is what we still need to do (but I do not intend to do it):

1. Update the algorithms in all the other volumes. Make sure to load the xparse package in the volume folder. This will likely add to the list of notations in notation_index.tex. I think we should define macros for new conventions whenever that is relevant.

2. Add guidelines to the ACME lab style guide, or whatever it's called. I will email what I have to Marissa and Amelia.